### PR TITLE
Dedupe optimizer loadouts by main-echo + canonical non-main order

### DIFF
--- a/src/calculator/optimizer.ts
+++ b/src/calculator/optimizer.ts
@@ -20,6 +20,51 @@ function echoCost(echo: { type?: unknown }): number {
   return Number.isFinite(n) ? n : 0;
 }
 
+function echoOptimizerSignature(echo: any): string {
+  if (!echo) return "";
+
+  return [
+    echo.echo ?? "",
+    echo.echoSet ?? "",
+    echo.type ?? "",
+    echo.rank ?? "",
+    echo.stat ?? "",
+    echo.echoSubStatsType1 ?? "",
+    echo.echoSubStatsValue1 ?? "",
+    echo.echoSubStatsType2 ?? "",
+    echo.echoSubStatsValue2 ?? "",
+    echo.echoSubStatsType3 ?? "",
+    echo.echoSubStatsValue3 ?? "",
+    echo.echoSubStatsType4 ?? "",
+    echo.echoSubStatsValue4 ?? "",
+    echo.echoSubStatsType5 ?? "",
+    echo.echoSubStatsValue5 ?? "",
+  ]
+    .map(String)
+    .join(":");
+}
+
+export function normalizeOptimizerLoadout(loadout: any[]): any[] {
+  if (!Array.isArray(loadout) || loadout.length <= 1) {
+    return loadout;
+  }
+
+  const [mainEcho, ...otherEchoes] = loadout;
+  return [
+    mainEcho,
+    ...otherEchoes
+      .slice()
+      .sort((a, b) =>
+        echoOptimizerSignature(a).localeCompare(echoOptimizerSignature(b)),
+      ),
+  ];
+}
+
+export function getOptimizerLoadoutKey(loadout: any[]): string {
+  const normalizedLoadout = normalizeOptimizerLoadout(loadout);
+  return normalizedLoadout.map(echoOptimizerSignature).join("|");
+}
+
 export function* generateLoadouts(
   echoes: any,
   mainEchoKeys = [],
@@ -323,12 +368,7 @@ export function optimize(
 
   // @ts-ignore
   for (const loadout of generateLoadouts(echoes, mainEchoKeys)) {
-    // Create a unique key for this combination based on echo keys, sorted
-    // Using echo.echoId to ensure we dont use the same specific echo, but we can use the same echoes
-    // @ts-ignore
-    const echoIds = loadout.map((echo) => echo.echoId);
-    echoIds.sort(); // Sort in place for better performance
-    const combinationKey = echoIds.join("|");
+    const combinationKey = getOptimizerLoadoutKey(loadout);
 
     // Skip if we've already seen this combination
     if (seenCombinations.has(combinationKey)) {
@@ -546,7 +586,9 @@ export function optimize(
       targetType,
       targetObject,
     };
-    const loadoutArr = JSON.parse(JSON.stringify(loadout));
+    const loadoutArr = JSON.parse(
+      JSON.stringify(normalizeOptimizerLoadout(loadout)),
+    );
     if (targetType === "Stat") {
       // get the stat wer'e looking for from our final stats
       targetValue = finalStats?.[targetObject] ?? 0;

--- a/src/components/Calculator.vue
+++ b/src/components/Calculator.vue
@@ -328,6 +328,7 @@ import {
 } from "../calculator/attacks";
 import { resolveRotationActionToAttackData } from "../calculator/resolveRotationAction";
 import type { OptimizerContext } from "../calculator/optimizer";
+import { getOptimizerLoadoutKey } from "../calculator/optimizer";
 import { getSetsFromEchoes, getSetBonusEffects } from "../echoes/sets";
 import { allEchoBuffs } from "../buffs";
 import { useCharacterStore } from "../stores/character";
@@ -1259,18 +1260,10 @@ export default defineComponent({
                 ) {
                   continue;
                 }
-                // Create key exactly like generator does
-                const echoIds: string[] = [];
-                for (const e of result.loadout) {
-                  if (e && e.echoId) {
-                    echoIds.push(String(e.echoId));
-                  }
-                }
-                if (echoIds.length === 0) {
+                if (result.loadout.length === 0) {
                   continue;
                 }
-                echoIds.sort();
-                const key = echoIds.join("|");
+                const key = getOptimizerLoadoutKey(result.loadout);
                 if (seenCombinations.has(key)) {
                   continue;
                 }

--- a/src/workers/generator.worker.ts
+++ b/src/workers/generator.worker.ts
@@ -24,7 +24,11 @@
  * - Deduplication happens in the worker to reduce main thread overhead
  */
 
-import { generateLoadouts } from "../calculator/optimizer";
+import {
+  generateLoadouts,
+  getOptimizerLoadoutKey,
+  normalizeOptimizerLoadout,
+} from "../calculator/optimizer";
 
 /**
  * Message sent from main thread to generator worker
@@ -81,16 +85,8 @@ self.onmessage = (e: MessageEvent<GeneratorMessage>) => {
       // @ts-ignore - generateLoadouts returns a generator with any[] items
       // @ts-ignore
       for (const loadout of generateLoadouts(echoes, mainEchoKeys)) {
-        // Create a unique key for this combination
-        const echoIds: string[] = [];
-        const loadoutArray = loadout as any[];
-        for (const e of loadoutArray) {
-          if (e && e.echoId) {
-            echoIds.push(String(e.echoId));
-          }
-        }
-        echoIds.sort();
-        const key = echoIds.join("|");
+        const normalizedLoadout = normalizeOptimizerLoadout(loadout as any[]);
+        const key = getOptimizerLoadoutKey(normalizedLoadout);
 
         // Skip if we've already seen this combination
         if (seenCombinations.has(key)) {
@@ -100,7 +96,7 @@ self.onmessage = (e: MessageEvent<GeneratorMessage>) => {
 
         // CRITICAL: Clone the loadout array because generateLoadouts mutates the combo array
         // If we push the reference directly, all loadouts will be the same (the last mutated value)
-        const clonedLoadout = JSON.parse(JSON.stringify(loadout));
+        const clonedLoadout = JSON.parse(JSON.stringify(normalizedLoadout));
         batch.push(clonedLoadout);
         totalGenerated++;
 

--- a/src/workers/processor.worker.ts
+++ b/src/workers/processor.worker.ts
@@ -19,7 +19,7 @@
  * 4. Worker sends "error" if batch processing fails
  *
  * Processing Steps (for each loadout):
- * 1. Extract echo IDs and create combination key
+ * 1. Normalize non-main echo ordering
  * 2. Calculate echo stats and set bonuses
  * 3. Compute character stats with echo buffs
  * 4. Calculate buffs (self, resonance chains, additional base, crit overflow)
@@ -38,7 +38,8 @@
  * - Context is pre-serialized by main thread (no functions, plain objects)
  */
 
-import { OptimizerContext } from "../calculator/optimizer";
+import type { OptimizerContext } from "../calculator/optimizer";
+import { normalizeOptimizerLoadout } from "../calculator/optimizer";
 import { getAttackData } from "../characters/characters";
 import { getCombinedEchoStats } from "../echoes/stats";
 import { getSetsFromEchoes, getSetBonusEffects } from "../echoes/sets";
@@ -114,20 +115,15 @@ function processLoadout(
   rotationData?: any, // Pre-processed rotation data for Rotation target type
 ): any | null {
   try {
-    // Create a unique key for this combination
-    const echoIds = loadout.map((echo) => echo.echoId);
-    echoIds.sort();
-
-    // Don't filter duplicates here - the main thread will handle that
-    // We still track it for reporting purposes
+    const normalizedLoadout = normalizeOptimizerLoadout(loadout);
 
     // Calculate echo stats and set bonuses
-    const echoStats = getCombinedEchoStats(loadout);
-    const echoSets = getSetsFromEchoes(loadout);
+    const echoStats = getCombinedEchoStats(normalizedLoadout);
+    const echoSets = getSetsFromEchoes(normalizedLoadout);
     const echoSetBonuses = getSetBonusEffects(echoSets);
     const setBonusOne = echoSetBonuses?.setBonusOne ?? null;
     const setBonusTwo = echoSetBonuses?.setBonusTwo ?? null;
-    const mainEchoKey = loadout[0]?.echo;
+    const mainEchoKey = normalizedLoadout[0]?.echo;
     const mainEchoBuff = mainEchoStats?.[mainEchoKey] ?? {};
 
     const setBonusOneBuffs =
@@ -357,7 +353,7 @@ function processLoadout(
       targetType,
       targetObject,
     };
-    const loadoutArr = JSON.parse(JSON.stringify(loadout));
+    const loadoutArr = JSON.parse(JSON.stringify(normalizedLoadout));
 
     if (targetType === "Stat") {
       targetValue = finalStats?.[targetObject] ?? 0;


### PR DESCRIPTION
The optimizer was generating up to 24 visually-identical loadouts per unique combination because the dedupe key sorted all five echoIds together. Only slot 0 (the main echo) contributes the on-slot stat bonus; slots 1-4 are position-agnostic.

Centralize the key in optimizer.ts (normalizeOptimizerLoadout + getOptimizerLoadoutKey): keep loadout[0] fixed, sort the remaining echoes by an effective-stat signature (echo / set / cost / main stat / substats / rank) so equivalent builds collapse even when their inventory echoIds differ. Apply it consistently in the generator worker, processor worker, and main-thread result dedupe.