### PR TITLE
docs(infoview): fix Resistance Multiplier prose typos

### DIFF
--- a/src/pages/InfoView.vue
+++ b/src/pages/InfoView.vue
@@ -64,10 +64,10 @@
       (800 + 8 * charLevel) / (800 + 8 * charLevel + (8 * enemyLevel + 792) * (1
       - defIgnore) * (1 - defReduction))
     </code>
-    <h4>Resist Multiplier</h4>
+    <h4>Resistance Multiplier</h4>
     <p>
-      Note: if the resistenceReduction makes the total resist go under 0, then
-      you half the remainder
+      Note: if the resistenceReduction makes the total resistance go under 0,
+      then you halve the remainder
     </p>
     <code>(1 - resistance + resistenceReduction)</code>
     <h3>Shields and Healing</h3>


### PR DESCRIPTION
## Summary

Closes #232. `src/pages/InfoView.vue:67-71` Resistance Multiplier section had three small word-choice issues. Fix the heading and the explanatory prose, leaving the code variable name `resistenceReduction` unchanged since renaming it would touch the calculator runtime and several cross-file callers - scope expansion the issue did not request.

## Why this matters

The reporter caught three flow-breaking word choices in the Info page:

- The heading "Resist Multiplier" used `Resist` as a noun. The actual noun is `Resistance`, and the surrounding code formula uses `resistance` correctly already.
- "total resist go under 0" - same noun issue.
- "you half the remainder" - `half` is a noun, the intended verb is `halve`.

This is the Info page that explains the damage formulas to players using the optimizer, so the prose should read cleanly.

## Changes

- `src/pages/InfoView.vue:67` - `<h4>Resist Multiplier</h4>` -> `<h4>Resistance Multiplier</h4>`.
- `src/pages/InfoView.vue:69` - `the total resist go under 0` -> `the total resistance go under 0`.
- `src/pages/InfoView.vue:70` - `you half the remainder` -> `you halve the remainder`.
- `src/pages/InfoView.vue:72` is intentionally untouched (`resistenceReduction` is the existing function-parameter spelling; renaming the variable would touch `src/calculator/calculator.ts` and the test fixtures).

## How to test

```
$ grep -n "Resist Multiplier\|total resist go\|you half the remainder" src/pages/InfoView.vue
(empty)
$ sed -n '67,72p' src/pages/InfoView.vue
    <h4>Resistance Multiplier</h4>
    <p>
      Note: if the resistenceReduction makes the total resistance go under 0,
      then you halve the remainder
    </p>
    <code>(1 - resistance + resistenceReduction)</code>
```

Fixes #232

AI-assisted.
